### PR TITLE
Use value from displayUsing callback parameter instead of $this->value

### DIFF
--- a/src/FieldServiceProvider.php
+++ b/src/FieldServiceProvider.php
@@ -24,8 +24,8 @@ class FieldServiceProvider extends ServiceProvider
 
         Textarea::macro('limit', function($amount, $ending = '...') {
             if(resolve(NovaRequest::class)->resourceId == null) {
-                $this->displayUsing(function() use($amount, $ending) {
-                    return str_limit($this->value, $amount, $ending);
+                $this->displayUsing(function($value) use($amount, $ending) {
+                    return str_limit($value, $amount, $ending);
                 });
             }
 


### PR DESCRIPTION
In Nova 3.5.0 (and possibly earlier versions) `$this->value` used in the displayUsing callback can be null. This fix uses the value provided to the callback function in a parameter.

Fix for #5 